### PR TITLE
Ignore case of gemeinde and street on the commandline

### DIFF
--- a/ahpi.py
+++ b/ahpi.py
@@ -1,6 +1,7 @@
 import requests
 from bs4 import BeautifulSoup, Comment
 import argparse
+import re
 
 def get_gemeinden():
     url = "https://www.aha-region.de/abholtermine/abfuhrkalender"
@@ -91,11 +92,17 @@ def __build_abholungen(gemeinde, street, hausnr, loading_place):
 
     return return_object
 
-def get_abholungen(gemeinde, input_street, hausnr, loading_place):
+def get_abholungen(input_gemeinde, input_street, hausnr, loading_place):
+    gemeinde = input_gemeinde.lower().capitalize()
     raw_streets = get_streets(gemeinde, input_street[0])
-    street = [ street for street in raw_streets if input_street in street ][0]
+    matching_streets = [ street for street in raw_streets if re.search(input_street, street, re.IGNORECASE) ]
+    matching_streets_count = len(matching_streets)
+    street = matching_streets[0] if matching_streets_count == 1 else usage_error("No matching street found") if matching_streets_count == 0 else usage_error("Street is ambigous: " + ", ".join(matching_streets))
 
     return __build_abholungen(gemeinde, street, hausnr, loading_place)
+
+def usage_error(msg):
+    raise Exception(msg)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Get Abfuhrdaten from the AHA Website')

--- a/ahpi.py
+++ b/ahpi.py
@@ -97,7 +97,15 @@ def get_abholungen(input_gemeinde, input_street, hausnr, loading_place):
     raw_streets = get_streets(gemeinde, input_street[0])
     matching_streets = [ street for street in raw_streets if re.search(input_street, street, re.IGNORECASE) ]
     matching_streets_count = len(matching_streets)
-    street = matching_streets[0] if matching_streets_count == 1 else usage_error("No matching street found") if matching_streets_count == 0 else usage_error("Street is ambigous: " + ", ".join(matching_streets))
+    street = (
+        matching_streets[0]
+        if matching_streets_count == 1
+        else (
+            usage_error("No matching street found")
+            if matching_streets_count == 0
+            else usage_error("Street is ambigous: " + ", ".join(matching_streets))
+        )
+    )
 
     return __build_abholungen(gemeinde, street, hausnr, loading_place)
 

--- a/ahpi.py
+++ b/ahpi.py
@@ -95,7 +95,11 @@ def __build_abholungen(gemeinde, street, hausnr, loading_place):
 def get_abholungen(input_gemeinde, input_street, hausnr, loading_place):
     gemeinde = input_gemeinde.lower().capitalize()
     raw_streets = get_streets(gemeinde, input_street[0])
-    matching_streets = [ street for street in raw_streets if re.search(input_street, street, re.IGNORECASE) ]
+    matching_streets = [
+        street
+        for street in raw_streets
+        if re.search(input_street, street, re.IGNORECASE)
+    ]
     matching_streets_count = len(matching_streets)
     street = (
         matching_streets[0]


### PR DESCRIPTION
This PR will allow to pass the street and gemeinde in arbitrary casings (`hannover`, `Hannover`, `HaNNover`)

It also adds an error if the given street is ambigous or could not be found.